### PR TITLE
missionTemplate - Fixed a 1st Person bug in ZEUS and VEHICLE

### DIFF
--- a/missionTemplate.VR/initPlayerLocal.sqf
+++ b/missionTemplate.VR/initPlayerLocal.sqf
@@ -32,14 +32,16 @@ fnc_hintDisplayTexts = {
 	hintSilent "";
 };
 
+
 player addEventHandler ["FiredNear", {
 	params ["_unit", "_firer", "_distance", "_weapon", "_muzzle", "_mode", "_ammo", "_gunner"];
 	if (!((vehicle player) == player)) exitWith {};
+	if (!(isNull getAssignedCuratorLogic player)) exitWith{};
 	countdownTime = time + 60;
 	if (alive player) then {
 		_unit spawn {
 			while { (countdownTime - time) > 0 } do {
-				if (cameraView == "EXTERNAL") then {
+				if (cameraView == "EXTERNAL" && (vehicle player) == player) then {
 					[" <t color='#FF0000'<t size='2.0'><img image='a3\ui_f_curator\data\rsccommon\rscattributebehaviour\combat_ca.paa'/></t><br/><br/>Vous êtes en combat !</t>", 5] spawn fnc_hintDisplayTexts;
 					player switchCamera "INTERNAL";
 					sleep 0.25;


### PR DESCRIPTION
- A bug occured when a zeus was fired near causing the camera to bug and freeze.
- When a player with the fired near script activated entered a vehicle, the player could not use the third person